### PR TITLE
Add Cue files for PSX

### DIFF
--- a/project/MANIFEST.xml
+++ b/project/MANIFEST.xml
@@ -388,6 +388,7 @@
          <extension>img</extension>
          <extension>bin</extension>
          <extension>iso</extension>
+         <extension>cue</extension>
       </extensions>
       <bios>
          <file md5="924e392ed05558ffdb115408c263dccf">SCPH1001.BIN</file>


### PR DESCRIPTION
For my system .cue files are used because of multiple .bin files are present for some games. This change allows for them to be seen in the gui for deletion or manipulation.